### PR TITLE
Developer docs updated with kernel module exposure, autocompletions and hybrid module guide

### DIFF
--- a/source/guides/hybrid_modules.rst
+++ b/source/guides/hybrid_modules.rst
@@ -1,0 +1,103 @@
+
+Hybrid C++/Python modules in `tudatpy`
+======================================
+
+This example shows how to create a hybrid C++/Python module in `tudatpy`.
+
+.. note::
+
+    If you're not familiar with the Python import system, it may be useful for you
+    to check out the developer documentation on kernel module exposure and autocompletion
+    in `tudatpy` first.
+
+The goal of this guide is to briefly explain how to create a hybrid C++/Python module in
+`tudatpy`. This is useful to combine C++ and Python functionality in a single `tudatpy`
+module.
+
+We will first consider the case in which you have implemented a new class, function or 
+other object in a C++ `tudat` kernel module, a Python module which uses this object to 
+provide some functionality, and want to expose them both.
+
+Then, we will consider the case in which you have created an entirely new C++ `tudat` kernel
+module, a Python script which makes use of its members to provide some functionality, and
+want to expose them both.
+
+Combining C++ and Python functionality in an existing `tudatpy` module
+----------------------------------------------------------------------
+
+`tudatpy/tudatpy`[1]_ contains all `tudatpy` modules, both the ones which wrap C++ `tudat` kernel
+modules and those which are pure Python.
+
+1. Find the `tudatpy` module which wraps the C++ `tudat` kernel module you want to combine with
+   your Python module.
+2. Place your Python module inside the `tudatpy` module wrapping the C++ `tudat` kernel module.
+    This will allow you to import the Python module and use its members, as well as the members
+    of the kernel module.
+3. Compile `tudatpy` using `build_and_expose_kernel.sh`[2]_.
+    This will expose the C++ `tudat` kernel module by wrapping it in a Python module (as well as provide
+    Python autocompletions for all its members).
+
+You're done! You have now combined Python and C++ inside a single `tudatpy` module.
+
+To get a feeling of how the final result should look like, you can check out the `tudatpy.trajectory_design`[3]_
+`tudatpy` module, which combines the C++ `shape_based_thrust` and `transfer_trajectory` modules and the Python 
+`porkchop` module.
+
+.. note::
+
+    You can make use of the `__init__.py`[4]_ of the `tudatpy` module which wraps the C++ `tudat` kernel module
+    to ease the import of the Python functionality you've just added to it.
+    
+    For example, you could add the following lines to the `__init__.py` of the `tudatpy.trajectory_design` module:
+    to make it easier to import the `trajectory_design.porkchop.porkchop` function::
+
+        from tudatpy.trajectory_design.porkchop import porkchop
+
+Combining C++ and Python functionality in a new `tudatpy` module
+----------------------------------------------------------------
+
+Two components are needed for this:
+
+1. A C++ `tudat` kernel module, exposed to Python using `pybind11`
+2. A Python wrapper of the module, which exposes it through `tudatpy`
+
+Create a C++ `tudat` module and expose to Python using `pybind11`
+#################################################################
+
+Please refer to the developer docs on exposing C++ modules for a detailed explanation.
+
+Expose the C++ `tudat` kernel module through `tudatpy`
+######################################################
+
+Once you have created your C++ kernel module, compile `tudatpy` using `build_and_expose_kernel.sh`[2]_.
+This will expose the new C++ `tudat` kernel module by wrapping it in a Python module (as well as provide
+Python autocompletions for all its members).
+
+Place your Python module inside the `tudatpy` module wrapping the C++ `tudat` kernel module
+###########################################################################################
+
+Move the Python module you want to combine with the kernel module inside the Python module
+which wraps the kernel module. This will allow you to import the Python module and use its
+members, as well as the members of the kernel module.
+
+To get a feeling of how the final result should look like, you can check out the `tudatpy.trajectory_design`[3]_
+`tudatpy` module, which combines the C++ `shape_based_thrust` and `transfer_trajectory` modules and the Python 
+`porkchop` module.
+
+.. note::
+
+    You can make use of the `__init__.py`[4]_ of the `tudatpy` module which wraps the C++ `tudat` kernel module
+    to ease the import of the Python functionality you've just added to it.
+    
+    For example, you could add the following lines to the `__init__.py` of the `tudatpy.trajectory_design` module:
+    to make it easier to import the `trajectory_design.porkchop.porkchop` function::
+
+        from tudatpy.trajectory_design.porkchop import porkchop
+
+References
+----------
+
+.. [1] `https://github.com/tudat-team/tudatpy/tree/master/tudatpy`_
+.. [2] `https://github.com/tudat-team/tudat-bundle/blob/main/build_and_expose_kernel.sh`_
+.. [3] `https://github.com/tudat-team/tudatpy/tree/master/tudatpy/trajectory_design`
+.. [4] `https://github.com/tudat-team/tudatpy/blob/master/tudatpy/trajectory_design/__init__.py`_

--- a/source/index.rst
+++ b/source/index.rst
@@ -63,6 +63,10 @@ references.
     :ref:`Extending Features`
 
     :ref:`Exposing C++ to Python`
+    
+    :ref:`Exposing kernel modules directly through tudatpy`
+
+    :ref:`Autocompletion in Python`
 
 
 
@@ -92,6 +96,7 @@ development, and documentation of Tudat.
    guides/new_tudat_class
    guides/new_tudat_module
    guides/pdf_with_sphinx
+   guides/hybrid_modules
 
 .. toctree::
    :maxdepth: 3

--- a/source/primer/software.rst
+++ b/source/primer/software.rst
@@ -10,6 +10,8 @@ Software Development
    software/environment
    software/exposing_cpp
    software/extending_features
+   software/kernel_module_exposure
+   software/autocompletion
 
 
 .. panels::

--- a/source/primer/software/autocompletion.rst
+++ b/source/primer/software/autocompletion.rst
@@ -1,0 +1,95 @@
+
+Autocompletion in Python
+========================
+
+This document describes how autocompletion works for Python modules, and explains
+the solution implemented in tudat to provide autocompletions for all Python *and*
+C++ modules (exposed through `pybind11`) in `tudatpy`.
+
+Introduction
+------------
+
+Autocompletion in Python is performed by a Python Language Server (VSCode uses such
+a server, and other IDEs as well), which works by scanning the current scope and
+using the active Python interpreter to gather information about installed packages
+and modules.
+
+For this to work for a given module it must be inspectable. The `tudat`
+kernel, exposed to Python using `pybind11` (`kernel.so`), is not.
+
+.. note::
+
+    This is likely related to an issue with the `def_submodule` function of `pybind11`, 
+    due to which exposed modules are not fully inspectable by the Python interpreter (see [1]_).
+
+The solution that hs been implemented in `tudatpy` is to create a Python module 
+that wraps each `tudat` kernel module, and explicitly imports all members of the
+kernel module. This way, the Python Language Server can inspect the module, and
+autocompletion works.
+
+Goal of this guide
+------------------
+
+The goal of this guide is to give you immediate insight into how:
+
+1. We implement autocompletion for kernel modules in `tudatpy`
+2. How we use the `expose_kernel_module.py`[2]_ script to automate this process
+3. How you can use `build_and_expose_kernel,sh`[3]_ to simultaneously build `tudatpy` and expose all kernel modules (to automatically add autocompletion for any new kernel members you may have exposed)
+
+Implementation in tudatpy
+-------------------------
+
+Autocompletion in `tudatpy` was implemented in pull request 128[4]_.
+
+To explain how this works, consider a `tudat` kernel module which is exposed through a 
+Python module which wraps it. The Python module 
+
+- lives inside `tudatpy`
+- has the same name as the kernel module
+- and has inside an `__init__.py` with the following statement: `from tudatpy.kernel.<kernel_module_name>import *` -this allows us to import all members of the kernel module from its Python wrapper-.
+
+For each such exposed kernel module, this pull request does the following:
+
+1. Next to the Python module's `__init__.py`, if and only if the module has **non-module** members (so classes, functions and other objects), a new file is created: `_import_all_kernel_members.py`
+2. `_import_all_kernel_members.py` explicitly imports all members (classes, functions and other objects) of the kernel module as follows: `from tudatpy.kernel.<module_name> import <member 1>, <member 2>, ...` (see [5]_)
+3. In the module's `__init__.py`, we import everything from `_import_all_kernel_members.py` (see [6]_)
+
+This way, all the _explicitly imported_  kernel members are accessible from the Python module 
+wrapping it: autocompletion engines will scan this, and detect all module members for autocompletion.
+
+The reason we do this with two files (`__init__.py` and `_import_all_kernel_members.py`) is that this 
+way users **can change the** `__init__.py` (which they may well want to do, as it is the `__init__.py` 
+of a _hybrid_ C++/_Python_ module), and we can **freely automatically generate** the `_import_all_kernel_members.py` 
+**overwriting the existing ones**, as these files will **never be manually changed**.
+
+Basically, this way we allow users to change `__init__.py`, and keep the liberty to blast away old versions 
+of all `_import_all_kernel_members.py`s when the kernel changes.
+
+How the process is automated
+----------------------------
+
+`expose_kernel_module.py`[2]_ automates this process. We will consider the `numerical_simulation` kernel module to
+explain how the script works. Given the name of the kernel module (`numerical_simulation`), `expose_kernel_module.py`[2]_ will:
+
+1. Expose (wrap) every submodule of `numerical_simulation` (create submodule directory and `__init__.py` file)
+2. For each submodule, create a `_import_all_kernel_members.py` file, which explicitly imports all **non-module** members of the submodule
+
+Simultaneously compiling `tudatpy`, exposing all kernel modules and enabling autocompletions
+--------------------------------------------------------------------------------------------
+
+The `build_and_expose_kernel.sh`[3]_ script automates the process of compiling `tudatpy` and exposing all kernel modules. It does the following:
+
+1. Builds `tudatpy` (by calling the `build.sh`[7]_, providing it with the number of cores to be used for compilation)
+2. Defines a list of kernel modules to be exposed (this is necessary as some kernel modules such as `io` and `util` are superseeded/wrapped by the `tudatpy` python modules `io` and `utils`)
+3. For each kernel module in the list, it calls `expose_kernel_module.py`[2]_ to expose the kernel module
+
+References
+----------
+
+.. [1] `https://github.com/pybind/pybind11/issues/2639`_
+.. [2] `https://github.com/tudat-team/tudatpy/blob/master/expose_kernel_module.py`_
+.. [3] `https://github.com/tudat-team/tudat-bundle/blob/main/build_and_expose_kernel.sh`_
+.. [4] `https://github.com/tudat-team/tudatpy/pull/128`_
+.. [5] `https://github.com/tudat-team/tudatpy/blob/master/tudatpy/math/interpolators/_import_all_kernel_members.py`_
+.. [6] `https://github.com/tudat-team/tudatpy/blob/master/tudatpy/math/interpolators/__init__.py`_
+.. [7] `https://github.com/tudat-team/tudat-bundle/blob/main/build.sh`_

--- a/source/primer/software/kernel_module_exposure.rst
+++ b/source/primer/software/kernel_module_exposure.rst
@@ -1,0 +1,100 @@
+
+Exposing kernel modules directly through tudatpy
+================================================
+
+The goal of this document is to concisely explain 
+
+1. Why we must come up with a solution to expose kernel modules directly through tudatpy
+2. How the solution works
+3. How the solution is automated with the `expose_kernel_module.py`[1]_ script
+4. How you can simultaneously compile `tudatpy` and expose all kernel modules directly through `tudatpy`
+
+.. note::
+
+    With "kernel exposure directly through `tudatpy`" we mean making it possible
+    to import kernel modules as follows::
+
+        from tudatpy.numerical_simulation import environment
+
+    instead of::
+
+        from tudatpy.kernel.numerical_simulation import environment
+
+Why we must come up with a solution to expose kernel modules directly through tudatpy
+-------------------------------------------------------------------------------------
+
+The reason a manual solution is needed is an issue with the `def_submodule` function of 
+`pybind11`, due to which exposed modules are not fully inspectable by the Python interpreter 
+(see [2]_).
+
+Previously, the `tudat` C++ kernel was exposed in `tudatpy` in the `tudatpy/__init__.py` as follows::
+
+    from tudatpy.kernel import *
+
+Due to the bug with the `def_submodule` function of `pybind11`, the Python interpreter **cannot inspect**
+the kernel modules imported with the start import, and thus imports such as the following **will fail**::
+
+    from tudatpy.numerical_simulation import environment
+
+The solution
+------------
+
+We will use the module `tudatpy.kernel.astro` to illustrate how kernel modules are exposed:
+
+1. A top-level `tudatpy` Python module, `tudatpy.astro`, is created to wrap `tudatpy.kernel.astro`. This top-level module consists of an empty directory with a an (empty) `__init__.py` inside
+2. In the `__init__.py` we **import** the kernel module `tudatpy.kernel.astro` as follows:: 
+        
+        `from tudatpy.kernel.astro import *`. 
+        
+      This makes it possible to import the kernel module in Python like this: `import tudatpy.astro`
+3. We add a [disclaimer](https://github.com/tudat-team/tudatpy/blob/60719404b37c8cfb747e9d4cd7ef6f865b148acf/tudatpy/trajectory_design/__init__.py#L1), clearly stating that the import statement has been automatically generated, and why.
+4. This process repeats for all submodules of `tudatpy.kernel.astro`
+
+Hybrid Python/C++ modules
+#########################
+
+It is possible to combine Python and C++ functionality inside the `tudatpy` modules which wrap `tudat` C++ kernel modules.
+Check the developer guide on hybrid modules for more details.
+
+The consequence is that the `__init__.py` of `tudatpy.astro` in our example may be edited later on to facilitate
+the import of Python functions and classes which are not part of the `tudat` C++ kernel module `astro`.
+
+To avoid overwriting/deleting meaningful content inside the `__init__.py` file, kernel modules are exposed as follows. We will
+consider the `tudatpy.trajectory_design` module as an example, which exposes the `tudat` C++ `trajectory_design` module
+as well as Python code:
+
+1. The entire `tudatpy/trajectory_design` Python module is copied to the **compiled tudatpy directory** `tudatpy/trajectory_design`
+2. After this is done, we check if `tudatpy/trajectory_design` **already contains** a top-level `__init__.py`
+    - **If it does**, we check if the `__init__.py` **already contains** the kernel module import statement:
+        - **If it does**, we do nothing
+        - **Else**, we **append** the import statement and disclaimer to the `__init__.py`
+    - Else, an `__init__.py` is created inside `tudatpy/trajectory_design` with the kernel module import statement and disclaimer
+
+How the process is automated
+----------------------------
+
+`expose_kernel_module.py`[1]_ automates this process. We will consider the `numerical_simulation` kernel module to
+explain how the script works. Given the name of the kernel module (`numerical_simulation`), `expose_kernel_module.py`[2]_ will:
+
+1. Expose (wrap) every submodule of `numerical_simulation` (create submodule directory and `__init__.py` file)
+2. For each submodule, create a `_import_all_kernel_members.py` file, which explicitly imports all **non-module** members of the submodule
+
+.. note::
+
+    `expose_kernel_module`[1]_ also enables autocompletions for all kernel variables (classes, functions, other objects).
+    Check the developer docs on autocompletion to see how this is done.
+
+Simultaneously compiling `tudatpy` and exposing all kernel modules (as well as enabling autocompletions)
+--------------------------------------------------------------------------------------------------------
+
+The `build_and_expose_kernel.sh`[3]_ script automates the process of compiling `tudatpy` and exposing all kernel modules. It does the following:
+
+1. Builds `tudatpy` (by calling the `build.sh`[7]_, providing it with the number of cores to be used for compilation)
+2. Defines a list of kernel modules to be exposed (this is necessary as some kernel modules such as `io` and `util` are superseeded/wrapped by the `tudatpy` python modules `io` and `utils`)
+3. For each kernel module in the list, it calls `expose_kernel_module.py`[2]_ to expose the kernel module
+
+References
+----------
+
+.. [1] `https://github.com/tudat-team/tudatpy/blob/master/expose_kernel_module.py`_
+.. [2] `https://github.com/pybind/pybind11/issues/2639`_


### PR DESCRIPTION
This pull request adds to the software developer docs two articles on

- Kernel module exposure
- Autocompletions

as well as a developer guide which explains how to create

- Hybrid C++/Python modules in tudatpy

These pieces of documentation complement pull requests

- https://github.com/tudat-team/tudatpy/pull/128, which implemented the definitive version of kernel module exposure and autocompletion in tudatpy
- and https://github.com/tudat-team/tudat-bundle/pull/10, which adds scripts to `tudat-bundle` to automate building and exposing+adding autocompletions for `tudatpy` kernel modules