### PR TITLE
fix missing sphinx dependency and jinja2 version conflicts

### DIFF
--- a/source/primer/docs/_static/environment.yaml
+++ b/source/primer/docs/_static/environment.yaml
@@ -8,9 +8,11 @@ dependencies:
   - sphinx-tabs
   - sphinx-copybutton
   - sphinxcontrib
+  - sphinxcontrib-contentui
   - sphinx-panels
   - nbsphinx
   - sphinx-gallery
   - ipython
   - jupyter
   - bump2version
+  - Jinja2<3.1


### PR DESCRIPTION
Hi all,

When trying to build the Tudat website following the [Sphinx documentation](https://tudat-developer.readthedocs.io/en/latest/primer/docs/sphinx.html), I ran into some version conflicts.
First, I got the issue that `environmentfilter` couldn't be imported from jinja2:

> ~/repos/tudat-space master ❯ sphinx-build -b html docs/source docs/build                        tudat-docs
> Traceback (most recent call last):
>   File "/home/lars/anaconda3/envs/tudat-docs/bin/sphinx-build", line 6, in <module>
>     from sphinx.cmd.build import main
>   File "/home/lars/anaconda3/envs/tudat-docs/lib/python3.7/site-packages/sphinx/cmd/build.py", line 25, in <module>
>     from sphinx.application import Sphinx
>   File "/home/lars/anaconda3/envs/tudat-docs/lib/python3.7/site-packages/sphinx/application.py", line 43, in <module>
>     from sphinx.registry import SphinxComponentRegistry
>   File "/home/lars/anaconda3/envs/tudat-docs/lib/python3.7/site-packages/sphinx/registry.py", line 24, in <module>
>     from sphinx.builders import Builder
>   File "/home/lars/anaconda3/envs/tudat-docs/lib/python3.7/site-packages/sphinx/builders/__init__.py", line 26, in <module>
>     from sphinx.util import import_object, logging, progress_message, rst, status_iterator
>   File "/home/lars/anaconda3/envs/tudat-docs/lib/python3.7/site-packages/sphinx/util/rst.py", line 21, in <module>
>     from jinja2 import Environment, environmentfilter
> ImportError: cannot import name 'environmentfilter' from 'jinja2' (/home/lars/anaconda3/envs/tudat-docs/lib/python3.7/site-packages/jinja2/__init__.py)

This was fixed by limiting the version of jinja2 to <3.1.

After that, I got the error that `sphinxcontrib.contentui` could not be imported:

> ~/repos/tudat-space master ❯ sphinx-build -b html docs/source docs/build                        tudat-docs
> Running Sphinx v3.5.3
> WARNING: while setting up extension sphinx.addnodes: node class 'meta' is already registered, its visitors will be overridden
> 
> Extension error:
> Could not import extension sphinxcontrib.contentui (exception: No module named 'sphinxcontrib.contentui')

which was then fixed by adding sphinxcontrib-contentui to the `environment.yaml`.

I hope this is the right place to change the environment file, if not please let me know!

Best regards,
Lars